### PR TITLE
Fix container/case around source/destination port choices

### DIFF
--- a/src/yang/ietf-access-control-list.yang
+++ b/src/yang/ietf-access-control-list.yang
@@ -445,7 +445,7 @@ module ietf-access-control-list {
                 if-feature match-on-tcp;
                 uses pf:acl-tcp-header-fields;
                 choice source-port {
-                  container source-port-range-or-operator {
+                  case source-port-range-or-operator {
                     uses pf:port-range-or-operator;
                     description
                       "Source port definition.";
@@ -455,7 +455,7 @@ module ietf-access-control-list {
                      a group of source ports.";
                 }
                 choice destination-port {
-                  container destination-port-range-or-operator {
+                  case destination-port-range-or-operator {
                     uses pf:port-range-or-operator;
                     description
                       "Destination port definition.";
@@ -472,7 +472,7 @@ module ietf-access-control-list {
                 if-feature match-on-udp;
                 uses pf:acl-udp-header-fields;
                 choice source-port {
-                  container source-port-range-or-operator {
+                  case source-port-range-or-operator {
                     uses pf:port-range-or-operator;
                     description
                       "Source port definition.";
@@ -482,7 +482,7 @@ module ietf-access-control-list {
                      a group of source ports.";
                 }
                 choice destination-port {
-                  container destination-port-range-or-operator {
+                  case destination-port-range-or-operator {
                     uses pf:port-range-or-operator;
                     description
                       "Destination port definition.";

--- a/src/yang/ietf-access-control-list.yang
+++ b/src/yang/ietf-access-control-list.yang
@@ -444,25 +444,29 @@ module ietf-access-control-list {
               container tcp {
                 if-feature match-on-tcp;
                 uses pf:acl-tcp-header-fields;
-                choice source-port {
-                  case source-port-range-or-operator {
-                    uses pf:port-range-or-operator;
+                container source-port {
+                  choice source-port {
+                    case source-port-range-or-operator {
+                      uses pf:port-range-or-operator;
+                      description
+                        "Source port definition.";
+                    }
                     description
-                      "Source port definition.";
+                      "Choice of specifying the source port or referring to
+                      a group of source ports.";
                   }
-                  description
-                    "Choice of specifying the source port or referring to
-                     a group of source ports.";
                 }
-                choice destination-port {
-                  case destination-port-range-or-operator {
-                    uses pf:port-range-or-operator;
+                container destination-port {
+                  choice destination-port {
+                    case destination-port-range-or-operator {
+                      uses pf:port-range-or-operator;
+                      description
+                        "Destination port definition.";
+                    }
                     description
-                      "Destination port definition.";
+                      "Choice of specifying a destination port or referring
+                      to a group of destination ports.";
                   }
-                  description
-                    "Choice of specifying a destination port or referring
-                     to a group of destination ports.";
                 }
                 description
                   "Rule set that matches TCP headers.";
@@ -471,25 +475,29 @@ module ietf-access-control-list {
               container udp {
                 if-feature match-on-udp;
                 uses pf:acl-udp-header-fields;
-                choice source-port {
-                  case source-port-range-or-operator {
-                    uses pf:port-range-or-operator;
+                container source-port {
+                  choice source-port {
+                    case source-port-range-or-operator {
+                      uses pf:port-range-or-operator;
+                      description
+                        "Source port definition.";
+                    }
                     description
-                      "Source port definition.";
+                      "Choice of specifying the source port or referring to
+                      a group of source ports.";
                   }
-                  description
-                    "Choice of specifying the source port or referring to
-                     a group of source ports.";
                 }
-                choice destination-port {
-                  case destination-port-range-or-operator {
-                    uses pf:port-range-or-operator;
+                container destination-port {
+                  choice destination-port {
+                    case destination-port-range-or-operator {
+                      uses pf:port-range-or-operator;
+                      description
+                        "Destination port definition.";
+                    }
                     description
-                      "Destination port definition.";
+                      "Choice of specifying a destination port or referring
+                      to a group of destination ports.";
                   }
-                  description
-                    "Choice of specifying a destination port or referring
-                     to a group of destination ports.";
                 }
                 description
                   "Rule set that matches UDP headers.";


### PR DESCRIPTION
This fixes the source and destination port container/choice/case so that both the data tree and schema tree look pretty.